### PR TITLE
fix: Currency conversion preview errors

### DIFF
--- a/src/components/pdf-generator/SettingsSidebar.tsx
+++ b/src/components/pdf-generator/SettingsSidebar.tsx
@@ -14,7 +14,7 @@ import {
 interface SettingsSidebarProps {
   formData: PDFFormData;
   errors: Record<string, string>;
-  handleInputChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>, forceNumber?: boolean) => void;
   updateDefaultExchangeRate: (rate: number) => void;
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
@@ -149,7 +149,7 @@ export function SettingsSidebar({
                           type="number"
                           name="defaultExchangeRate"
                           value={formData.defaultExchangeRate}
-                          onChange={handleInputChange}
+                          onChange={(e) => handleInputChange(e, true)}
                           step="0.01"
                           min="0"
                           className="w-full p-2 border rounded-md"

--- a/src/hooks/usePDFForm.ts
+++ b/src/hooks/usePDFForm.ts
@@ -209,11 +209,12 @@ export function usePDFForm() {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>, forceNumber?: boolean) => {
     const { name, value } = e.target;
+
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: forceNumber ? Number(value) : value
     }));
     
     // Clear error when field is edited


### PR DESCRIPTION
fixes client crashes due to currency conversion input not converting string value into a Number.